### PR TITLE
Update command_led_example.py

### DIFF
--- a/advanced/commands/command_led_example.py
+++ b/advanced/commands/command_led_example.py
@@ -40,7 +40,7 @@ sleep(3)
 
 # Set the LED purple. Note that this override automatically sets the alpha
 # channel to "255" (e.g., arguments are RGB).
-group_command.led.color = hebi.Color(0, 255, 255)
+group_command.led.color = hebi.Color(255, 0, 255)
 group.send_command(group_command)
 
 sleep(3)


### PR DESCRIPTION
You mentioned purple (line 41), but (0,255,255) is light blue not purple. Purple is (255,0,255). Other libraries (repos) have this problem also.